### PR TITLE
게스트 수 전역 상태 관리 / 편의 시설 모달UI

### DIFF
--- a/src/components/template/detail/AccommodationInfo.tsx
+++ b/src/components/template/detail/AccommodationInfo.tsx
@@ -1,3 +1,4 @@
+import { GuestCount } from '../../../interfaces/interface';
 import {
   StyledOnClick,
   StyledSelect,
@@ -13,8 +14,14 @@ import {
 import APIServiceList from './APIServiceList';
 interface AccommodationProp {
   onOpen: (e: React.MouseEvent) => void;
+  guestCount: GuestCount;
+  totalGuestCount: number;
 }
-const AccommodationInfo = ({ onOpen }: AccommodationProp) => {
+const AccommodationInfo = ({
+  onOpen,
+  guestCount,
+  totalGuestCount,
+}: AccommodationProp) => {
   return (
     <StyledWrap>
       <StyledTitle>마리나베이 속초</StyledTitle>
@@ -53,7 +60,10 @@ const AccommodationInfo = ({ onOpen }: AccommodationProp) => {
             <StyledText $fontSize="1rem" $fontWeight={700}>
               게스트
             </StyledText>
-            <StyledText $fontSize="1rem"> 성인 n명 / 아동 n명</StyledText>
+            <StyledText $fontSize="1rem">
+              성인 {guestCount.adults}명 / 아동 {guestCount.children}명 / 유아
+              {guestCount.infants}명 &nbsp;::&nbsp; 총 {totalGuestCount}명
+            </StyledText>
           </StyledFlexContainer>
           <StyledOnClick onClick={onOpen}>수정</StyledOnClick>
         </StyledSelect>

--- a/src/components/template/detail/DetailContainer.tsx
+++ b/src/components/template/detail/DetailContainer.tsx
@@ -2,15 +2,44 @@ import ImageContainer from './ImageContainer';
 import AccommodationInfo from './AccommodationInfo';
 import RoomCard from './RoomCard';
 import DetailService from './DetailService';
+import GuestModal from './GuestModal/guestModal';
+import { useState } from 'react';
+import { GuestCount } from '../../../interfaces/interface';
+interface DetailContainerProps {}
+const DetailContainer = ({}: DetailContainerProps) => {
+  const [guestCount, setGuestCount] = useState<GuestCount>({
+    adults: 0,
+    children: 0,
+    infants: 0,
+  });
+  const [totalGuestCount, setTotalGuestCount] = useState(0);
+  const [showGuestModal, setShowGuestModal] = useState(false);
+  const handleGuestModal = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // setShowGuestModal(true);
+    setShowGuestModal(!showGuestModal);
+  };
+  const handleSaveGuestCount = (newGuestCount: number) => {
+    setTotalGuestCount(newGuestCount); //게스트 수 상태 업데이트
+    setShowGuestModal(false);
+  };
 
-interface DetailContainerProps {
-  onOpen: (e: React.MouseEvent) => void;
-}
-const DetailContainer = ({ onOpen }: DetailContainerProps) => {
   return (
     <>
       <ImageContainer />
-      <AccommodationInfo onOpen={onOpen} />
+      <AccommodationInfo
+        onOpen={handleGuestModal}
+        guestCount={guestCount}
+        totalGuestCount={totalGuestCount}
+      />
+      {showGuestModal && (
+        <GuestModal
+          guestCount={guestCount}
+          setGuestCount={setGuestCount}
+          onClose={() => setShowGuestModal(false)}
+          onSave={handleSaveGuestCount}
+        />
+      )}
       <RoomCard />
       <DetailService />
     </>

--- a/src/components/template/detail/DetailService.tsx
+++ b/src/components/template/detail/DetailService.tsx
@@ -1,7 +1,8 @@
 import {
   StyledBorderWrap,
   StyledServiceWrap,
-  StyledSubText,
+  StyledH2Text,
+  StyledBorderBtn,
 } from '../../../style/detail/detailStyle';
 import { StyledFlexContainer } from '../../../style/payment/paymentStyle';
 import APIServiceList from './APIServiceList';
@@ -10,13 +11,13 @@ import EssentialServiceList from './EssentialServiceList';
 const DetailService = () => {
   return (
     <StyledBorderWrap>
-      <StyledSubText $mt="0rem" $mb="2rem" $color="#444">
+      <StyledH2Text $mt="0rem" $mb="2rem">
         숙소 편의시설
-      </StyledSubText>
+      </StyledH2Text>
       <StyledServiceWrap
         $flexDirection="row"
         $alignItems="flex-end"
-        $justifyContent="space-evenly">
+        $justifyContent="space-between">
         <StyledFlexContainer
           className="service-col"
           $flexDirection="column"
@@ -31,36 +32,12 @@ const DetailService = () => {
           $gap="1rem">
           <APIServiceList />
         </StyledFlexContainer>
-        {/*    <SmallButtonBlack className="service-col">
+        <StyledBorderBtn $variant="primary" className="service-col">
           편의시설 모두 보기
-        </SmallButtonBlack> */}
+        </StyledBorderBtn>
       </StyledServiceWrap>
     </StyledBorderWrap>
   );
 };
 
 export default DetailService;
-
-// 편의시설 버튼 제거 ?
-/* export const SmallButtonBlack = styled(SmallButton)`
-  width: 10rem;
-  color: #444;
-  border: 1px solid #444;
-  background-color: #fff;
-  white-space: nowrap;
-  font-weight: ${(props) => props.theme.fontWeights.medium};
-  transition: background-color 0.3s ease;
-  margin-right:1rem;
-
-  &:hover {
-    background-color: #444;
-    color:#fff;
-
-  &:focus {
-    outline: none;
-  }
-  &:disabled {
-    color: ${(props) => props.theme.colors.gray};
-    background-color: ${(props) => props.theme.colors.lightGray};
-  }
-`; */

--- a/src/components/template/detail/DetailService.tsx
+++ b/src/components/template/detail/DetailService.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import {
   StyledBorderWrap,
   StyledServiceWrap,
@@ -7,8 +9,16 @@ import {
 import { StyledFlexContainer } from '../../../style/payment/paymentStyle';
 import APIServiceList from './APIServiceList';
 import EssentialServiceList from './EssentialServiceList';
+import FacilityModal from './FacilityModal';
 
 const DetailService = () => {
+  const [showFacilityModal, setShowFacilityModal] = useState(false);
+
+  const handleFacilityModal = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log('modal open');
+    setShowFacilityModal(true);
+  };
   return (
     <StyledBorderWrap>
       <StyledH2Text $mt="0rem" $mb="2rem">
@@ -32,9 +42,15 @@ const DetailService = () => {
           $gap="1rem">
           <APIServiceList />
         </StyledFlexContainer>
-        <StyledBorderBtn $variant="primary" className="service-col">
+        <StyledBorderBtn
+          $variant="primary"
+          className="service-col"
+          onClick={handleFacilityModal}>
           편의시설 모두 보기
         </StyledBorderBtn>
+        {showFacilityModal && (
+          <FacilityModal onClose={() => setShowFacilityModal(false)} />
+        )}
       </StyledServiceWrap>
     </StyledBorderWrap>
   );

--- a/src/components/template/detail/FacilityModal.tsx
+++ b/src/components/template/detail/FacilityModal.tsx
@@ -1,0 +1,45 @@
+import { useRef } from 'react';
+import { useClickOutside } from '../../../hooks/useClickOutside';
+import { StyledH2Text } from '../../../style/detail/detailStyle';
+import APIServiceList from './APIServiceList';
+import EssentialServiceList from './EssentialServiceList';
+import {
+  StyledCloseButton,
+  StyledModalWrapper,
+  StyledModalContent,
+} from '../../../style/detail/commonModalStyles';
+import styled from 'styled-components';
+
+interface FacilityModalProps {
+  onClose: () => void;
+}
+
+const FacilityModal = ({ onClose }: FacilityModalProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useClickOutside(ref, () => {
+    onClose();
+  });
+  return (
+    <StyledModalWrapper>
+      <StyledFacilityModal ref={ref}>
+        <StyledCloseButton onClick={onClose}>X</StyledCloseButton>
+        <StyledH2Text>숙소 편의시설</StyledH2Text>
+        <APIServiceList />
+        <StyledH2Text className="modalTitle"> 객실 편의시설</StyledH2Text>
+        <EssentialServiceList />
+      </StyledFacilityModal>
+    </StyledModalWrapper>
+  );
+};
+
+export default FacilityModal;
+const StyledFacilityModal = styled(StyledModalContent)`
+  width: 500px;
+
+  & p {
+    width: 100%;
+    padding: 0.2rem 1rem;
+    border-bottom: 1px solid #ccc;
+    font-size: ${(props) => props.theme.fontSizes.md};
+  }
+`;

--- a/src/components/template/detail/GuestModal/guestAgeGroup.tsx
+++ b/src/components/template/detail/GuestModal/guestAgeGroup.tsx
@@ -4,7 +4,7 @@ import {
   StyledFlexContainer,
   StyledText,
 } from '../../../../style/payment/paymentStyle';
-import { StyledSubText } from '../../../../style/detail/detailStyle';
+import { StyledH2Text } from '../../../../style/detail/detailStyle';
 interface GuestAgeGroupProps {
   text: string;
   subText: string;
@@ -26,9 +26,7 @@ const guestAgeGroup = ({
         $flexDirection="column"
         $alignItems="flex-start"
         $gap=".8rem">
-        <StyledSubText $color="#444" $mb="0">
-          {text}
-        </StyledSubText>
+        <StyledH2Text $mb="0">{text}</StyledH2Text>
         <StyledTextGray> {subText} </StyledTextGray>
       </StyledTextBox>
       <StyledGuestCount $gap="1rem">

--- a/src/components/template/detail/GuestModal/guestContent.tsx
+++ b/src/components/template/detail/GuestModal/guestContent.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { GuestCount } from '../../../../interfaces/interface';
 import GuestAgeGroup from './guestAgeGroup';
 import styled from 'styled-components';
@@ -7,15 +6,22 @@ import { StyledButton } from '../../../../style/common/commonStyle';
 interface GuestContentProps {
   onSave: (totalGuests: number) => void;
   onClose: () => void;
+  guestCount: GuestCount;
+  setGuestCount: React.Dispatch<React.SetStateAction<GuestCount>>;
 }
 
-const GuestContent = ({ onSave, onClose }: GuestContentProps) => {
-  const [guestCount, setGuestCount] = useState<GuestCount>({
+const GuestContent = ({
+  guestCount,
+  setGuestCount,
+  onSave,
+  onClose,
+}: GuestContentProps) => {
+  /*   const [guestCount, setGuestCount] = useState<GuestCount>({
     adults: 0,
     children: 0,
     infants: 0,
   } as GuestCount);
-
+ */
   const updateGuestCount = (type: keyof GuestCount, action: string) => {
     if (action === 'increase') {
       setGuestCount((prevCount) => ({

--- a/src/components/template/detail/GuestModal/guestModal.tsx
+++ b/src/components/template/detail/GuestModal/guestModal.tsx
@@ -1,22 +1,35 @@
 import { useRef } from 'react';
 import { useClickOutside } from '../../../../hooks/useClickOutside';
 import GuestContent from './guestContent';
-import styled from 'styled-components';
 import { StyledText } from '../../../../style/payment/paymentStyle';
 import { StyledH2Text } from '../../../../style/detail/detailStyle';
+import { GuestCount } from '../../../../interfaces/interface';
+import {
+  StyledCloseButton,
+  StyledModalContent,
+  StyledModalWrapper,
+} from '../../../../style/detail/commonModalStyles';
 
 interface GuestModalProps {
   onClose: () => void;
+  onSave: (totalGuests: number) => void;
+  guestCount: GuestCount;
+  setGuestCount: React.Dispatch<React.SetStateAction<GuestCount>>;
 }
 
-const GuestModal = ({ onClose }: GuestModalProps) => {
+const GuestModal = ({
+  onClose,
+  onSave,
+  guestCount,
+  setGuestCount,
+}: GuestModalProps) => {
   const ref = useRef<HTMLDivElement>(null);
   useClickOutside(ref, () => {
     onClose();
   });
-
-  const onSave = (totalGuests: number) => {
+  const handleSave = (totalGuests: number) => {
     console.log('총 게스트:', totalGuests, '명');
+    onSave(totalGuests); // 상위 컴포넌트 handleSaveGuestCount 호출
   };
 
   return (
@@ -27,50 +40,15 @@ const GuestModal = ({ onClose }: GuestModalProps) => {
           게스트
         </StyledH2Text>
         <StyledText>이 숙소의 최대 숙박 인원은 n명 입니다.</StyledText>
-        <GuestContent onClose={onClose} onSave={onSave} />
+        <GuestContent
+          guestCount={guestCount}
+          setGuestCount={setGuestCount}
+          onClose={onClose}
+          onSave={handleSave}
+        />
       </StyledModalContent>
     </StyledModalWrapper>
   );
 };
 
 export default GuestModal;
-
-const StyledModalWrapper = styled.div`
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
-  z-index: 1;
-  background: rgba(0, 0, 0, 0.6);
-  cursor: pointer;
-`;
-const StyledModalContent = styled.div`
-  max-width: 1200px;
-  position: fixed;
-  height: auto;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  z-index: 1;
-  box-shadow:
-    0 0 0 1px rgba(0, 0, 0, 0.04),
-    0 8px 16px rgba(0, 0, 0, 0.15);
-  border-radius: 5px;
-  color: #000;
-  background: #fff;
-  padding: 2rem;
-`;
-const StyledCloseButton = styled.div`
-  font-size: ${(props) => props.theme.fontSizes.lg};
-  font-weight: ${(props) => props.theme.fontWeights.bold};
-  position: absolute;
-  right: 0.8rem;
-  top: 0.8rem;
-  cursor: pointer;
-`;

--- a/src/components/template/detail/GuestModal/guestModal.tsx
+++ b/src/components/template/detail/GuestModal/guestModal.tsx
@@ -3,7 +3,7 @@ import { useClickOutside } from '../../../../hooks/useClickOutside';
 import GuestContent from './guestContent';
 import styled from 'styled-components';
 import { StyledText } from '../../../../style/payment/paymentStyle';
-import { StyledSubText } from '../../../../style/detail/detailStyle';
+import { StyledH2Text } from '../../../../style/detail/detailStyle';
 
 interface GuestModalProps {
   onClose: () => void;
@@ -23,9 +23,9 @@ const GuestModal = ({ onClose }: GuestModalProps) => {
     <StyledModalWrapper>
       <StyledModalContent ref={ref}>
         <StyledCloseButton onClick={onClose}>X</StyledCloseButton>
-        <StyledSubText $color="#444" $fontSize="1.5rem" $textAlign="left">
+        <StyledH2Text $fontSize="1.5rem" $textAlign="left">
           게스트
-        </StyledSubText>
+        </StyledH2Text>
         <StyledText>이 숙소의 최대 숙박 인원은 n명 입니다.</StyledText>
         <GuestContent onClose={onClose} onSave={onSave} />
       </StyledModalContent>

--- a/src/components/template/detail/ImageContainer.tsx
+++ b/src/components/template/detail/ImageContainer.tsx
@@ -18,6 +18,7 @@ const ImageContainer: React.FC = () => {
 
 export default ImageContainer;
 export const StyledGridImgWrap = styled.div`
+  margin-top: 4rem;
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;
   grid-gap: 1rem;

--- a/src/components/template/detail/RoomCard.tsx
+++ b/src/components/template/detail/RoomCard.tsx
@@ -8,7 +8,7 @@ import {
   StyledFlexRowGroup,
   StyledImgItem,
   StyledTextItem,
-  StyledSubText,
+  StyledH2Text,
   StyledPriceText,
   StyledTextRow,
   StyledReservationBtn,
@@ -36,7 +36,7 @@ const RoomCard = () => {
           $gap="1rem">
           <div>
             <StyledFlexContainer $flexDirection="row">
-              <StyledSubText $color="#444">숙박</StyledSubText>
+              <StyledH2Text>숙박</StyledH2Text>
               <StyledOnClick onClick={handleDetailModal}>
                 상세보기
               </StyledOnClick>
@@ -44,9 +44,14 @@ const RoomCard = () => {
                 <DetailModal setShowModal={setShowDetailModal} />
               )}
             </StyledFlexContainer>
-            <StyledSubText $fontSize="1rem" $mt="0" $mb="0" $fontWeight={400}>
+            <StyledH2Text
+              $color="darkGray"
+              $fontSize="1rem"
+              $mt="0"
+              $mb="0"
+              $fontWeight={400}>
               체크인: 15:00~체크아웃:11:00
-            </StyledSubText>
+            </StyledH2Text>
           </div>
           <StyledPriceText>400000원</StyledPriceText>
           <StyledFlexContainer $flexDirection="row">
@@ -61,7 +66,7 @@ const RoomCard = () => {
         </StyledTextItem>
       </StyledFlexRowGroup>
       <StyledFlexContainer $flexDirection="column" $alignItems="flex-start">
-        <StyledSubText $color="#444">더블 스탠다드 룸</StyledSubText>
+        <StyledH2Text>더블 스탠다드 룸</StyledH2Text>
         <StyledTextRow>
           <LuUser className="icon" />
           기준 2인 | 최대 2인

--- a/src/components/template/detail/RoomCard.tsx
+++ b/src/components/template/detail/RoomCard.tsx
@@ -16,8 +16,10 @@ import {
 import { StyledFlexContainer } from '../../../style/payment/paymentStyle';
 import CartBtn from '../../layout/Button/cartBtn';
 import DetailModal from './detailModal/detailModal';
-
-const RoomCard = () => {
+interface RoomCardProps {
+  // totalGuestCount: number;
+}
+const RoomCard = ({}: RoomCardProps) => {
   const [showDetailModal, setShowDetailModal] = useState(false);
   const handleDetailModal = () => {
     setShowDetailModal(true);

--- a/src/pages/detail/detail.tsx
+++ b/src/pages/detail/detail.tsx
@@ -1,22 +1,9 @@
 import DetailContainer from '../../components/template/detail/DetailContainer';
-import GuestModal from '../../components/template/detail/GuestModal/guestModal';
-
-import { useState } from 'react';
 
 const Detail = () => {
-  const [showGuestModal, setShowGuestModal] = useState(false);
-  const handleGuestModal = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setShowGuestModal(true);
-  };
-
   return (
     <div>
-      <DetailContainer onOpen={handleGuestModal} />
-
-      {showGuestModal && (
-        <GuestModal onClose={() => setShowGuestModal(false)} />
-      )}
+      <DetailContainer />
     </div>
   );
 };

--- a/src/style/detail/commonModalStyles.ts
+++ b/src/style/detail/commonModalStyles.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const StyledModalWrapper = styled.div`
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  background: rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+`;
+export const StyledModalContent = styled.div`
+  max-width: 1200px;
+  position: fixed;
+  height: auto;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  z-index: 1;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.04),
+    0 8px 16px rgba(0, 0, 0, 0.15);
+  border-radius: 5px;
+  color: #000;
+  background: #fff;
+  padding: 2rem;
+`;
+export const StyledCloseButton = styled.div`
+  font-size: ${(props) => props.theme.fontSizes.lg};
+  font-weight: ${(props) => props.theme.fontWeights.bold};
+  position: absolute;
+  right: 0.8rem;
+  top: 0.8rem;
+  cursor: pointer;
+`;

--- a/src/style/detail/detailStyle.ts
+++ b/src/style/detail/detailStyle.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { StyledFlexContainer } from '../payment/paymentStyle';
 import { StyledButton } from '../common/commonStyle';
+import { StyledBlackBtn } from '../../components/template/detail/GuestModal/guestContent';
 
 export const StyledWrap = styled.article`
   position: relative;
@@ -36,13 +37,14 @@ export const StyledServiceInfo = styled(StyledFlexContainer)<{
 `;
 
 export const StyledServiceWrap = styled(StyledServiceInfo)`
+  padding: 1rem;
   & .service-col > p {
     font-size: ${(props) => props.theme.fontSizes.md};
     display: block;
     flex-shrink: none;
   }
 `;
-export const StyledSubText = styled.h2<{
+export const StyledH2Text = styled.h2<{
   $fontSize?: string;
   $fontWeight?: number;
   $color?: string;
@@ -52,7 +54,7 @@ export const StyledSubText = styled.h2<{
 }>`
   font-size: ${(props) => props.$fontSize || props.theme.fontSizes.lg};
   font-weight: ${(props) => props.$fontWeight || props.theme.fontWeights.bold};
-  color: ${(props) => props.$color || props.theme.colors.darkGray};
+  color: ${(props) => props.$color || '#444'};
   margin-top: ${(props) => props.$mt || '1rem'};
   margin-bottom: ${(props) => props.$mb || '1rem'};
   line-height: 1rem;
@@ -126,6 +128,18 @@ export const StyledTextItem = styled(StyledFlexContainer)`
 export const StyledReservationBtn = styled(StyledButton)`
   width: 10rem;
   padding: 0.6rem 2rem;
+`;
+
+export const StyledBorderBtn = styled(StyledBlackBtn)`
+  background-color: transparent;
+  color: #444;
+  border: 1px solid #444;
+  padding: 0.6rem 2rem;
+  transition: background-color 0.3s;
+  &:hover {
+    background-color: #444;
+    color: #fff;
+  }
 `;
 
 export const StyledTextRow = styled.p<{


### PR DESCRIPTION
## 작업 개요 (이슈 번호)
#14
## 작업 내용 (변경 사항)
- 게스트 수 상태 detailContainer.tsx로 이동
- 게스트 수  변경 내용 [게스트] 선택/수정 영역에 반영
- 편의시설 상세보기 버튼 원복 / 상세보기 모달 추가
- 기타 스타일링 수정

## 스크린샷
![image](https://github.com/TR1LL1ON/TR1LL1ON_FE/assets/131247158/13750353-d8c1-4b93-be57-13d506cc6cbb)
![image](https://github.com/TR1LL1ON/TR1LL1ON_FE/assets/131247158/72370027-6f2f-42f4-850f-a4e7b31554bd)

## Check list
- [ ] 테스트 통과
- [ ] 문서 업데이트
