### PR TITLE
장바구니 선택 상품 결제페이지로 이동

### DIFF
--- a/src/components/template/cart/CartList.tsx
+++ b/src/components/template/cart/CartList.tsx
@@ -15,14 +15,15 @@ const CartList = ({
 }: ICartListProps) => {
   return (
     <StyledCartList $flexDirection="column" $justifyContent="flex-start">
-      {cartsData.map((cart, index) => (
-        <CartCard
-          cartData={cart}
-          key={index}
-          checkedCartsData={checkedCartsData}
-          setCheckedCartsData={setCheckedCartsData}
-        />
-      ))}
+      {cartsData &&
+        cartsData.map((cart, index) => (
+          <CartCard
+            cartData={cart}
+            key={index}
+            checkedCartsData={checkedCartsData}
+            setCheckedCartsData={setCheckedCartsData}
+          />
+        ))}
     </StyledCartList>
   );
 };

--- a/src/components/template/cart/index.tsx
+++ b/src/components/template/cart/index.tsx
@@ -10,6 +10,7 @@ import CartListController from './CartListController';
 import { useEffect, useState } from 'react';
 import { Cart } from '@/interfaces/interface';
 import { getCarts } from '@/api/service';
+import { useNavigate } from 'react-router-dom';
 
 export interface IFormValue {
   name: string;
@@ -19,8 +20,16 @@ export interface IFormValue {
 }
 
 const CartContainer = () => {
+  const navigate = useNavigate();
   const [cartsData, setCartsData] = useState<Cart[]>([]);
   const [checkedCartsData, setCheckedCartsData] = useState<Cart[]>([]);
+
+  const handleSubmit = (): void => {
+    const productIds = checkedCartsData.map((cart) => cart.productId);
+    const queryString = productIds.map((id) => `productId=${id}`).join('&');
+
+    navigate(`/payment?${queryString}`);
+  };
 
   useEffect(() => {
     const fetchData = async (): Promise<void> => {
@@ -52,7 +61,10 @@ const CartContainer = () => {
       />
       <StyledHLine $mBlock="1rem" />
       <CartDetail />
-      <StyledButton style={{ width: '100%' }} $variant="primary">
+      <StyledButton
+        style={{ width: '100%' }}
+        $variant="primary"
+        onClick={handleSubmit}>
         결제하기
       </StyledButton>
     </StyledWrapper>


### PR DESCRIPTION
## 작업 개요 (이슈 번호)

close #78 

## 작업 내용 (변경 사항)

장바구니에서 선택한 상품 결제페이지로 보낼 때 query string을 이용하여 URL에 담아서 전달

## 스크린샷

![image](https://github.com/TR1LL1ON/TR1LL1ON_FE/assets/121606131/179a7e92-5529-4fd7-8df8-6cca9e9a3fde)
